### PR TITLE
Fixing search of products with blank space in the string

### DIFF
--- a/org.adempiere.pos/src/main/java/base/org/adempiere/pos/service/CPOS.java
+++ b/org.adempiere.pos/src/main/java/base/org/adempiere/pos/service/CPOS.java
@@ -2320,10 +2320,10 @@ public class CPOS {
 				sql.append("AND p.AD_Client_ID=? AND p.IsSold=? AND p.Discontinued=? ")
 				.append("AND ")
 				.append("(")
-				.append("UPPER(p.Name)  LIKE UPPER('").append("%").append(productCode.replace(" ","%")).append("%").append("')")
-				.append(" OR UPPER(p.Value) LIKE UPPER('").append("%").append(productCode.replace(" ","%")).append("%").append("')")
-				.append(" OR UPPER(p.UPC)   LIKE UPPER('").append("%").append(productCode.replace(" ","%")).append("%").append("')")
-				.append(" OR UPPER(p.SKU)   LIKE UPPER('").append("%").append(productCode.replace(" ","%")).append("%").append("')")
+				.append("UPPER(p.Name)  LIKE UPPER('").append("%").append(productCode).append("%").append("')")
+				.append(" OR UPPER(p.Value) LIKE UPPER('").append("%").append(productCode).append("%").append("')")
+				.append(" OR UPPER(p.UPC)   LIKE UPPER('").append("%").append(productCode).append("%").append("')")
+				.append(" OR UPPER(p.SKU)   LIKE UPPER('").append("%").append(productCode).append("%").append("')")
 				.append(")");
 		PreparedStatement statement = null;
 		try{


### PR DESCRIPTION
In the method CPOS.getQueryProduct, it filters with SQL using the like an replacing the blank space with "%" (line 2324) but when refresh the combo in the method AutoComplete.refresh (line 132) the code filters with the java string.contains.
This cause that in the first place, the string "tech 21" with the like is equals to "tech21", but in the second place, both "tech 21" and "tech21" are not equals, this fail in the product suggestion box selecting an incorrect product