### PR TITLE
Redmine #14671

### DIFF
--- a/org.spin.loan_management/src/main/java/base/org/spin/util/LoanDunningProcess.java
+++ b/org.spin.loan_management/src/main/java/base/org/spin/util/LoanDunningProcess.java
@@ -114,9 +114,11 @@ public class LoanDunningProcess extends AbstractFunctionalSetting {
 			}
 			//	Summary for Amortization
 			MFMAmortization amortization = new MFMAmortization(getCtx(), amortizationReferencia.getAmortizationId(), trxName);
-			amortization.setCurrentCapitalAmt(capitalAmount.get());
-			amortization.setCurrentDunningAmt(dunningAmount.get());
-			amortization.setCurrentDunningTaxAmt(dunningTaxAmount.get());
+			amortization.setCurrentCapitalAmt(amortizationReferencia.getCapitalAmtFee());
+			amortization.setCurrentDunningAmt(amortizationReferencia.getDunningInterestAmount());
+			amortization.setCurrentDunningTaxAmt(amortizationReferencia.getDunningTaxAmt());
+			amortization.setCurrentInterestAmt(amortizationReferencia.getInterestAmtFee());
+			amortization.setCurrentTaxAmt(amortizationReferencia.getTaxAmtFee());
 			amortization.saveEx();
 			//	Set Interest
 			MFMAmortizationSummary.setCurrentDunning(getCtx(), account.getFM_Account_ID(), amortizationReferencia.getAmortizationId(), batch.getDateDoc(), capitalAmount.get(), dunningAmount.get(), dunningTaxAmount.get(), trxName);


### PR DESCRIPTION
Hola @yamelsenih, estoy revisando el Proceso de Cálculo de Mora en la clase **LoanDunningProcess** y veo que para cada columna de las cuotas hay unas variables totalizadoras que se utilizan para cargar la MFMAmortizationSummary, el tema es que inmediatamente antes, se establecen cada una de las cuotas (MFMAmortization) con estos totalizadores.
Esta corrección aplica para que se establezca el valor correcto en cada cuota.