### PR TITLE
Bugfix/#co fixed update role access

### DIFF
--- a/base/src/org/compiere/process/RoleAccessUpdate.java
+++ b/base/src/org/compiere/process/RoleAccessUpdate.java
@@ -52,25 +52,23 @@ public class RoleAccessUpdate extends RoleAccessUpdateAbstract {
         getProcessLog().info("AD_Client_ID=" + getClientId() + ", AD_Role_ID="
                 + getRoleId());
 
-        List<Object> params = new ArrayList<>();
-        StringBuffer whereClause = new StringBuffer();
+        if (getRoleId() >= 0) {
+            updateRole(getRole(getRoleId()));
+        } else {
+            List<Object> params = new ArrayList<>();
+            String whereClause = "";
 
-        whereClause.append("AD_Client_ID=?");
-        params.add(getClientId());
-        //	
-        if(getClientId() == 0) {
-        	whereClause.append(" AND AD_Role_ID=?");
-            params.add(getRoleId());
-        } else if(getRoleId() > 0) {
-        	whereClause.append(" AND AD_Role_ID=?");
-            params.add(getRoleId());
+            if (getClientId() > 0) {
+                whereClause = "AD_Client_ID=?";
+                params.add(getClientId());
+            }
+
+            getRoleQuery(whereClause)
+                    .setOnlyActiveRecords(true)
+                    .setParameters(params)
+                    .setOrderBy("AD_Client_ID, Name")
+                    .<MRole>list().stream().forEach(this::updateRole);
         }
-        //	
-        getRoleQuery(whereClause.toString())
-                .setOnlyActiveRecords(true)
-                .setParameters(params)
-                .setOrderBy("AD_Client_ID, Name")
-                .<MRole>list().stream().forEach(this::updateRole);
 
         return "";
 


### PR DESCRIPTION
Removed the call to MRole(ctx, 0, trxName) and replaced it with a query for all roles.  Tests pass and manually tested within the System Client and GW Client for specific roles and all roles.  Was able to access the system account normally after each test.