### PR TITLE
the base joins the platform as evidence, and is never written to

### DIFF
--- a/.ai/knowledge.md
+++ b/.ai/knowledge.md
@@ -1,0 +1,149 @@
+# Knowledge Contract — adempiere
+
+> Standard: `knowledge-contract-v1`. Authored from repository evidence on
+> 2026-09-02, at `59557cc2`, without a release: this repository's first contract
+> is written by hand because generating it from a release would mean creating a
+> release for no other reason. Subsequent revisions come from
+> `knowledge-on-release` when upstream is merged and tagged.
+
+## 1. Identity
+
+| Field | Value |
+|---|---|
+| Repository | `erpcya/adempiere` |
+| Classification | `Base` |
+| Entity type | `D` |
+| Owner | ERP Consultores y Asociados |
+| Upstream | `adempiere/adempiere` |
+| Branch read | `feature/erpya/master` |
+| Changes | `never` — see `organization/DR-0003` |
+
+This is this installation's fork of the ADempiere community base, at 3.9.4.001.
+
+**It carries no local source changes.** Compared against `adempiere/adempiere`
+`master`, this branch is three commits ahead and zero behind, and all three are
+merges — the file-level difference is empty. That is a fact worth stating plainly
+in section 1, because the whole architecture depends on it: the value of this fork
+is that it is *identical* to upstream and can therefore absorb upstream freely.
+
+## 2. Responsibility
+
+The base provides what every ADempiere installation has: the data dictionary, the
+persistence layer and its generated models, document processing, accounting,
+inventory, business partners, and the Swing and ZK clients that present them.
+
+For this platform its responsibility is different from every other repository's:
+**it is the evidence, not a destination.** Most functional questions — how an order
+completes, when a payment allocates, which callout fires on a field — are
+questions about code that lives here. An analysis that will not read this
+repository cannot answer them.
+
+## 3. Architecture
+
+29 Gradle modules (`settings.gradle`). The ones that matter to routing:
+
+| Module | Contains |
+|---|---|
+| `base/` | Models, processes, accounting, the dictionary — the bulk of business logic |
+| `client/` | The Swing desktop client and its controllers |
+| `zkwebui/` | The ZK web UI |
+| `org.adempiere.*`, `org.eevolution.*`, `org.spin.*` | Functional extensions shipped with the base |
+| `migration/` | Applied SQL migrations, by release |
+
+Built with Gradle. The version comes from `ADEMPIERE_LIBRARY_VERSION`, defaulting
+to `local-1.0.0`, and the published `base` artifact is what the libraries in this
+installation compile against — `io.github.adempiere:base:3.9.4`.
+
+## 4. Dependencies
+
+Upstream `adempiere/adempiere`, merged by hand and tagged. Nothing in this
+installation is a dependency of the base; the arrow points the other way.
+
+## 5. Consumers
+
+Everything. Directly:
+
+- `erpcya/adempiere_patch`, `adempiere_patch_swing`, `adempiere_patch_zk` — the
+  patches, which **shadow classes from this repository on the classpath**. This is
+  the mechanism section 7 depends on.
+- The libraries — `adempiere-pos-improvements`, `adempiere-dashboard-improvements`,
+  `LVE`, `withholding-engine`, `adempiere-jwt-token`,
+  `adempiere-business-processors`, `adempiere-payroll-multi-engine` — which compile
+  against `io.github.adempiere:base:3.9.4`.
+
+A change to a base class signature is a change to every one of them, and none of
+them is built in this repository's CI. That is the risk in section 9.
+
+## 6. Allowed changes
+
+**Only this repository describing itself:**
+
+- `.ai/**` — this contract, the marker, decision records
+- `.github/workflows/**` — the platform's actions
+
+Merging upstream and tagging a release is a human activity and is not a change
+this platform proposes.
+
+## 7. Prohibited changes
+
+**Every change to source.** Not minimized, not justified case by case, not
+permitted for a sufficiently important fix: none. See `organization/DR-0003`.
+
+The reason is arithmetic rather than principle. A line changed here is a line
+somebody reconciles by hand on every future upstream merge, forever, and the
+person paying that cost is not the person who made the change. Today the
+file-level diff against upstream is empty (§1) and merges are therefore cheap.
+Every local edit is a permanent tax on that.
+
+**What to do instead.** Copy the file into the patch that shadows it and edit the
+copy. The patch is chosen by where the file lives here — `client/` to
+`adempiere_patch_swing`, `zkwebui/` to `adempiere_patch_zk`, everything else to
+`adempiere_patch` — as declared in `.ai/repository.yml`. The copy records the
+commit it was taken at.
+
+## 8. Architectural rules
+
+- A class in a patch with the same fully-qualified name as one here **shadows it
+  at runtime**. That is the override mechanism, and it is why prohibiting changes
+  here costs nothing functionally.
+- Generated classes — `X_*`, `I_*`, generated abstract process classes — are
+  produced from the dictionary and are never hand-edited, here or in a copy.
+- An applied migration is never edited. A correction is a new migration.
+- An extracted copy must record its source commit. Without it, no later process
+  can determine whether this repository has moved underneath the copy.
+
+## 9. Risks
+
+**A stale override is invisible.** This is the risk the whole arrangement creates
+and the one worth stating first. When a file copied into a patch is later fixed
+here, the copy keeps the old behaviour: it compiles, it runs, and nothing reports
+it. The recorded source commit is the only thing that makes the question
+answerable, and answering it is work `release-impact` must do on each release of
+this repository.
+
+**No consumer is built here.** The libraries and patches that compile against the
+base are built in their own repositories. A signature change that breaks seven
+downstream repositories passes this repository's CI.
+
+**The fork is two years behind in wall-clock time.** The last merge from upstream
+is 2023-12-11. This is a fact, not a defect — 3.9.4.001 is what runs in production
+— but an analysis should not assume a fix present in upstream today is present
+here.
+
+## 10. Current state
+
+At `59557cc2`, `feature/erpya/master`, three merge commits ahead of upstream
+`master`, no file-level divergence. No release has been published from this fork,
+so this contract has no `knowledge-on-release` predecessor.
+
+## 11. UNKNOWN
+
+- **Whether any patch already overrides a given base file, and at which commit.**
+  Nothing has recorded that until now. The first extractions will establish it;
+  existing overrides in the three patch repositories predate the rule and carry no
+  source-commit header. **Whether those existing copies are current is unknown and
+  cannot be derived** — they must be checked one by one, or accepted as unverified.
+- **The upstream merge cadence.** Two years since the last merge is observable;
+  whether that is intentional is not recorded.
+- **Which modules are actually deployed.** 29 modules are declared; which ones this
+  installation ships is not stated anywhere in this repository.

--- a/.ai/repository.yml
+++ b/.ai/repository.yml
@@ -1,0 +1,57 @@
+# Read by the ERP AI knowledge platform. Declarative, not authoritative: an agent
+# derives the classification from evidence and reports a disagreement with this
+# file as an UNKNOWN rather than resolving it.
+type: Base
+entityType: D
+owner: ERP Consultores y Asociados
+
+# The community base. This fork exists so the platform has a base to read and so
+# this installation can carry upstream merges on its own branch.
+upstream: https://github.com/adempiere/adempiere
+branch: feature/erpya/master
+
+# This repository is evidence, never a destination. See organization/DR-0003.
+#
+# `never` does not mean the platform ignores it — the base is where most behaviour
+# actually lives, and an analysis that cannot read it concludes nothing. It means
+# no proposal ever lands here: when behaviour in this tree must change, the change
+# is a copy of the file into a patch, edited there, because the patch shadows this
+# on the classpath.
+#
+# The exception is this repository describing itself: its contract, its marker and
+# the platform's own workflows. Its source tree is never a target.
+changes: never
+changes_allowed_paths:
+  - .ai/**
+  - .github/workflows/**
+
+# Where an override lands, decided by where the file lives here rather than argued
+# per proposal. First match wins; the last entry is the general case.
+overrides:
+  - when: client/
+    repository: erpcya/adempiere_patch_swing
+    because: controller and desktop-client code
+  - when: zkwebui/
+    repository: erpcya/adempiere_patch_zk
+    because: the web UI
+  - when: "**"
+    repository: erpcya/adempiere_patch
+    because: the general case, base/ included
+
+# The words people use for this when they report something. Deliberately broad:
+# this is the repository nearly every functional report is ultimately about.
+terms:
+  - orden
+  - documento
+  - completar
+  - asiento
+  - contabilidad
+  - almacén
+  - producto
+  - socio de negocio
+  - pago
+  - asignación
+  - impuesto
+  - ventana
+  - proceso
+  - diccionario

--- a/.github/workflows/knowledge-on-release.yml
+++ b/.github/workflows/knowledge-on-release.yml
@@ -1,0 +1,149 @@
+# Copy this to .github/workflows/knowledge-on-release.yml in each repository the
+# platform documents.
+#
+# On a published release it asks the knowledge service what the release did to the
+# knowledge. Two filters decide whether a human hears about it: only a
+# CONTRACTS_STALE verdict regenerates the contract, and only a regenerated contract
+# that actually differs opens a pull request. Most releases produce neither, which
+# is the point — a pull request that arrives for every release teaches reviewers to
+# approve without reading.
+#
+# Two secrets, per repository or defined for the organization:
+#
+#   ERP_AI_URL     https://plus.erpya.com/tools/knowledge
+#   ERP_AI_TOKEN   whatever the proxy in front of the service accepts
+#
+# And one repository variable that decides whether it may open a pull request:
+#
+#   ERP_AI_PUBLISH   true, or absent
+#
+# Absent means evaluate and report, which is where a repository should start. Turn
+# it on once you have watched a few releases and agree with what the verdicts say —
+# a pull request opened by something you have not yet learned to trust is worse
+# than no pull request, because you will read the first two and skim the rest.
+#
+# This job submits and exits. It does not wait: a model call takes minutes, a
+# private repository's runner is billed by the minute, and waiting bought nothing
+# that could not be delivered another way. The service posts the verdict as a commit
+# status on the released commit, under the context `erp-ai/knowledge`, and opens a
+# pull request when one is warranted.
+#
+# For the status to appear, the token the service uses needs `Commit statuses:
+# write` on this repository. GITHUB_ALLOWED is not consulted for it: that list
+# answers "may I propose code here", and a status is a notification aimed at the
+# repository that asked. Opening the pull request does consult it.
+#
+# The service reads the repository from its own mounted clone, not from this runner,
+# so what it evaluates is what it last fetched.
+
+name: Knowledge on release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  evaluate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0        # tags, to find what this release moved from
+
+      - name: Find the previous release tag
+        id: previous
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # The release before this one. Without it there is no range to evaluate,
+          # and a first release has nothing to compare against — which is not a
+          # failure.
+          #
+          # Asked of the releases rather than of the tags. Two failures made the
+          # earlier version filter tags by hand: repositories accumulate tags that
+          # are not releases — `rs-2.1`, `RC-1.3.7`, a branch snapshot — and under
+          # `-v:refname` a leading letter outranks every digit, so the newest release
+          # lost to something tagged years ago. The filter that fixed both required a
+          # tag to be numeric, which is a guess about how somebody names a release
+          # and it was wrong: `adempiere-3.9.4-1.3.6` matched nothing, so a
+          # repository whose every tag names its base version would never have its
+          # contract regenerated, silently, for ever.
+          #
+          # A release is a thing GitHub knows about. Ordered by when it was
+          # published, so no ordering is inferred from a name, and drafts are not
+          # releases.
+          #
+          # `--is-ancestor` stays: a release that exists is not necessarily behind
+          # this one, and a parallel maintenance line read as this release's
+          # predecessor produces a plausible range and a confident verdict about a
+          # diff nobody shipped.
+          tag='${{ github.event.release.tag_name }}'
+
+          # Only the line this platform tracks, which is the repository's default
+          # branch. A contract describes one line of development; a release cut from
+          # a maintenance branch describes a different one, and regenerating the
+          # contract from it would replace what the current line says with what an
+          # older line still does.
+          #
+          # The default branch rather than a name written here: a fork keeps
+          # upstream's branch untouched and makes its own the default, and that
+          # choice is already recorded where GitHub can be asked for it.
+          line=$(gh api "repos/$GITHUB_REPOSITORY" -q .default_branch)
+          if ! git merge-base --is-ancestor "$tag" "origin/$line" 2>/dev/null; then
+            echo "$tag is not on $line, which is the line this platform tracks."
+            echo "Nothing regenerated: a contract describes one line, and this"
+            echo "release belongs to another."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          previous=""
+          for candidate in $(gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
+                             --paginate -q '.[] | select(.draft | not) | .tag_name'); do
+            [ "$candidate" = "$tag" ] && continue
+            git rev-parse -q --verify "refs/tags/$candidate" >/dev/null || continue
+            if git merge-base --is-ancestor "$candidate" "$tag^" 2>/dev/null; then
+              previous="$candidate"; break
+            fi
+          done
+          if [ -z "$previous" ]; then
+            # Asked anyway, with an empty range. A repository with no contract yet
+            # gets its first one written — the service checks that before it looks
+            # at any range — and this step used to decide not to ask, so a first
+            # release on a line produced nothing at all and said "nothing to
+            # compare" as though that were the whole answer.
+            #
+            # Where a contract does exist, the empty range is a no-op the service
+            # reports as such. The judgement belongs there: it holds the contract
+            # and this step does not.
+            echo "No earlier release on this line. Asking anyway: a repository"
+            echo "without a contract gets its first one, and one that has a"
+            echo "contract already will find the range empty."
+            echo "previous=$tag" >> "$GITHUB_OUTPUT"
+          else
+            echo "Evaluating $previous..${{ github.event.release.tag_name }}"
+            echo "previous=$previous" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Ask the knowledge service
+        if: steps.previous.outputs.skip != 'true'
+        id: submit
+        run: |
+          response=$(curl -sS -X POST "${{ secrets.ERP_AI_URL }}/chain" \
+            -H "Authorization: Bearer ${{ secrets.ERP_AI_TOKEN }}" \
+            -H 'content-type: application/json' \
+            -d '{
+                  "repository": "${{ github.repository }}",
+                  "since": "${{ steps.previous.outputs.previous }}",
+                  "until": "${{ github.event.release.tag_name }}",
+                  "sha": "${{ github.sha }}",
+                  "publish": ${{ vars.ERP_AI_PUBLISH == 'true' && format('"{0}"', github.repository) || 'null' }}
+                }')
+          echo "$response"
+          job=$(echo "$response" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("job",""))')
+          [ -n "$job" ] || { echo "The service did not accept the request."; exit 1; }
+          echo "Submitted $job. The verdict arrives as a commit status on ${{ github.sha }},"
+          echo "not here — a model call takes minutes and a runner that waits for one is"
+          echo "billed for sleeping. Read it on the commit, or ask the service:"
+          echo "  GET \$ERP_AI_URL/jobs/$job"

--- a/.github/workflows/pull-request-review.yml
+++ b/.github/workflows/pull-request-review.yml
@@ -1,0 +1,108 @@
+# Copy this to .github/workflows/erp-ai-review.yml in each repository where this
+# platform opens pull requests — the code repositories, not the one where issues are
+# filed. They are different repositories, and this belongs in the one holding the
+# change.
+#
+# Two labels, both applied to a pull request:
+#
+#   erp-ai:reanalyse   the diagnosis was wrong. Closes this and asks the question again.
+#   erp-ai:rework      the diagnosis was right and the change was not. Rewrites it here.
+#
+# Create both labels in this repository first. A label that does not exist cannot be
+# applied, and nothing will tell you why nothing happened.
+#
+# Which one to use, in one test: **if the change were perfectly written, would it
+# solve your problem?** Yes means `rework`. No means `reanalyse` — no amount of better
+# code gets there from here.
+#
+# Comment first, then label. The label is the trigger, so the service reads the
+# comments that exist at that moment; one added afterwards did not arrive. Say what
+# the change missed, in whichever of the three places suits you — a review, a comment
+# on a line of the diff, or the conversation tab. All three are read.
+#
+# The trigger is `pull_request`, not `issues`, and the difference is not cosmetic.
+# The REST API treats a pull request as an issue — /issues/16/comments answers for
+# pull request 16 — but the webhook events are separate, and `issues` does not fire
+# for pull requests at all. A workflow listening on `issues` for a label applied to a
+# pull request is not misconfigured; it is deaf. Nothing runs, nothing fails, and the
+# Actions tab stays empty, which reads exactly like a workflow that was never
+# installed.
+#
+# `pull_request_target` rather than `pull_request`, for one reason: it takes the
+# workflow file and the secrets from the **base branch**, where this file lives.
+#
+# `pull_request` takes them from the merge ref — the pull request's branch merged with
+# the base — which usually contains this file too, and stops containing anything the
+# moment the pull request has a conflict. A review workflow that goes silent exactly
+# when a change is contentious is the wrong failure to design in.
+#
+# What makes `pull_request_target` dangerous elsewhere does not apply here: the danger
+# is running code authored in the pull request while holding the repository's secrets.
+# **This job checks nothing out and runs nothing from the pull request.** It sends a
+# number to a service. There is no step that could execute what a contributor wrote.
+
+name: ERP AI on pull request review
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+jobs:
+  send-back:
+    if: >
+      github.event.label.name == 'erp-ai:reanalyse' ||
+      github.event.label.name == 'erp-ai:rework' 
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      # Off before anything else, so the label is an instruction rather than a state.
+      # It has to be re-applied to run again, which is right: after a rework the
+      # commit has changed and the previous answer is stale. Five re-labels went into
+      # discovering that removing and re-adding is the only way to fire `labeled`
+      # twice — this makes the removal somebody else's job.
+      - name: Take the label off, so it can be applied again
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.pull_request.number }}
+          LABEL: ${{ github.event.label.name }}
+          API: ${{ github.api_url }}
+        run: |
+          curl -sS -X DELETE -H "authorization: Bearer $GH_TOKEN" \
+            "$API/repos/$REPO/issues/$NUMBER/labels/$LABEL" > /dev/null || true
+
+      - name: Send the review back to the step that was wrong
+        env:
+          # Through the environment, never interpolated into the script: `${{ }}` is
+          # substituted as text before the shell parses the line.
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.pull_request.number }}
+          LABEL: ${{ github.event.label.name }}
+          SERVICE: ${{ secrets.ERP_AI_URL }}
+          SERVICE_TOKEN: ${{ secrets.ERP_AI_TOKEN }}
+        run: |
+          set -euo pipefail
+          action="${LABEL#erp-ai:}"
+
+          response=$(jq -n \
+            --arg repo "$REPO" --argjson num "$NUMBER" --arg action "$action" \
+            '{repository: $repo, pull_number: $num, action: $action}' \
+            | curl -sS -X POST "$SERVICE/review" \
+                -H "Authorization: Bearer $SERVICE_TOKEN" \
+                -H 'content-type: application/json' --data @-)
+          echo "$response"
+
+          # A 409 here is a real answer, not a hiccup: the pull request is already
+          # closed, or it does not say which issue it is for. Failing makes it
+          # visible, because silently doing nothing looks identical to working.
+          echo "$response" | jq -e .job > /dev/null \
+            || { echo "The service did not accept the review."; exit 1; }
+
+          if [ "$action" = "reanalyse" ]; then
+            echo "Submitted. This pull request will be closed and the issue analysed"
+            echo "again; the new analysis arrives as a comment on the issue."
+          else
+            echo "Submitted. The change will be written again on this branch, so this"
+            echo "pull request and its review thread stay as they are."
+          fi


### PR DESCRIPTION
This repository joins the platform as **evidence, not a destination**. It gets a marker, a contract, and two workflows. Its source tree is not touched and, by the rule this establishes, never will be.

## The rule

`organization/DR-0003`: **the base is read, never written.**

The previous rule said base modification must be *minimized*. That is not a rule an agent can apply — it names no threshold, so every proposal that reaches it has to argue, and one wrong argument becomes permanent maintenance nobody chose. A line changed here is a line somebody reconciles by hand on every future upstream merge.

Changing base behaviour does not require changing base source. The patches shadow classes on the classpath, so the change is **a copy of the file in the patch, edited there**. Which patch is derived from where the file lives, declared in `.ai/repository.yml` rather than argued per proposal:

| Base source | Patch |
|---|---|
| `client/` | `erpcya/adempiere_patch_swing` |
| `zkwebui/` | `erpcya/adempiere_patch_zk` |
| anything else | `erpcya/adempiere_patch` |

This is enforced, not just written down: the service reads the marker and refuses per path, and the refusal names the destination.

## What the contract records

Authored from evidence at `59557cc2`, by hand rather than from a release — generating it the usual way would have meant publishing a release for no other reason.

The finding that matters most is in §1: **compared against `adempiere/adempiere` master, this branch is three commits ahead, zero behind, and the file-level diff is empty.** All three are merges. This fork carries no local source changes at all, which is exactly why upstream merges are still cheap here — and exactly what this rule protects.

§9 states the risk the arrangement creates rather than hiding it: **a stale override is invisible.** When a file copied into a patch is later fixed here, the copy keeps the old behaviour — it compiles, it runs, and nothing reports it. That is why an extracted copy records the commit it came from, and why §11 lists the existing overrides in the three patches as **unknown**: they predate the rule, carry no source commit, and whether they are current cannot be derived. They have to be checked one by one or accepted as unverified.

## The workflows

- `knowledge-on-release.yml` — fires when a release is published here. That is the moment this fork changes: upstream merged, tagged, and the contract re-read against what moved.
- `pull-request-review.yml` — for the pull requests this platform opens here, which are only ever its own `.ai/` documents.

**The six existing workflows are upstream's and are untouched.**

## What this does not do

No release is created. The first contract is in this pull request precisely so that one is not needed; the next revision comes from `knowledge-on-release` when you next merge upstream and tag.