### PR TITLE
the patches are in erpya, and the destination is a package not a path

### DIFF
--- a/.ai/knowledge.md
+++ b/.ai/knowledge.md
@@ -63,9 +63,14 @@ installation is a dependency of the base; the arrow points the other way.
 
 Everything. Directly:
 
-- `erpcya/adempiere_patch`, `adempiere_patch_swing`, `adempiere_patch_zk` — the
+- `erpya/adempiere_patch`, `adempiere_patch_swing`, `adempiere_patch_zk` — the
   patches, which **shadow classes from this repository on the classpath**. This is
-  the mechanism section 7 depends on.
+  the mechanism section 7 depends on. They are the same layer and different
+  surfaces — `adempiere_patch_swing` carries `APanel` and `AEnv`, Swing
+  controllers; `adempiere_patch_zk` carries `AdempiereWebUI` and `GridPanel`.
+  Their markers record that as `surface`, not as `type`: typing them `Swing UI`
+  and `Web UI` would import that classification's rule against reusable business
+  logic, and overriding a controller is behaviour.
 - The libraries — `adempiere-pos-improvements`, `adempiere-dashboard-improvements`,
   `LVE`, `withholding-engine`, `adempiere-jwt-token`,
   `adempiere-business-processors`, `adempiere-payroll-multi-engine` — which compile
@@ -97,9 +102,22 @@ Every local edit is a permanent tax on that.
 
 **What to do instead.** Copy the file into the patch that shadows it and edit the
 copy. The patch is chosen by where the file lives here — `client/` to
-`adempiere_patch_swing`, `zkwebui/` to `adempiere_patch_zk`, everything else to
-`adempiere_patch` — as declared in `.ai/repository.yml`. The copy records the
-commit it was taken at.
+`erpya/adempiere_patch_swing`, `zkwebui/` to `erpya/adempiere_patch_zk`, everything
+else to `erpya/adempiere_patch` — as declared in `.ai/repository.yml`. The patches
+are in `erpya`; this fork is in `erpcya`.
+
+**The destination is computed from the package, not copied from the path.** The
+three patches do not share a source-root convention, and the marker declares each
+one's. Verified file by file:
+
+| | here | patch |
+|---|---|---|
+| Swing | `client/src/org/compiere/apps/APanel.java` | `src/main/java/base/org/compiere/apps/APanel.java` |
+| ZK | `zkwebui/WEB-INF/src/…/GridPanel.java` | `zkwebui/WEB-INF/src/…/GridPanel.java` |
+| core | `base/src/org/compiere/model/MOrder.java` | `base/src/main/java/base/org/compiere/model/MOrder.java` |
+
+A file placed at this repository's path inside the Swing patch compiles and
+shadows nothing. The copy records the commit it was taken at.
 
 ## 8. Architectural rules
 

--- a/.ai/repository.yml
+++ b/.ai/repository.yml
@@ -27,15 +27,33 @@ changes_allowed_paths:
 
 # Where an override lands, decided by where the file lives here rather than argued
 # per proposal. First match wins; the last entry is the general case.
+# `source_root` is not decoration. Shadowing works on the fully-qualified name, so
+# what must be preserved is the *package* — and the three patches do not agree on
+# where their source root is. Verified file by file:
+#
+#   base   client/src/org/compiere/apps/APanel.java
+#   patch  src/main/java/base/org/compiere/apps/APanel.java     (different root)
+#
+#   base   zkwebui/WEB-INF/src/.../GridPanel.java
+#   patch  zkwebui/WEB-INF/src/.../GridPanel.java               (same path)
+#
+# Writing "the same path" would have produced a file in the wrong place for the
+# Swing patch, which compiles and shadows nothing.
 overrides:
   - when: client/
-    repository: erpcya/adempiere_patch_swing
+    strip: client/src/
+    repository: erpya/adempiere_patch_swing
+    source_root: src/main/java/base/
     because: controller and desktop-client code
   - when: zkwebui/
-    repository: erpcya/adempiere_patch_zk
-    because: the web UI
+    strip: ""
+    repository: erpya/adempiere_patch_zk
+    source_root: ""
+    because: the web UI, which mirrors the base path exactly
   - when: "**"
-    repository: erpcya/adempiere_patch
+    strip: base/src/
+    repository: erpya/adempiere_patch
+    source_root: base/src/main/java/base/
     because: the general case, base/ included
 
 # The words people use for this when they report something. Deliberately broad:


### PR DESCRIPTION
Two corrections to the routing table merged in #85. Both were found by checking the repositories, not by rereading what I had written.

## The patches are in `erpya`, not `erpcya`

The merged table names `erpcya/adempiere_patch`, `erpcya/adempiere_patch_swing` and `erpcya/adempiere_patch_zk`. **None of those exist.** The three patches live in the `erpya` organization; this fork lives in `erpcya`.

A routing table that names repositories that do not exist fails at the one moment it is needed — when an analysis has concluded correctly and is trying to say where the change goes.

## The destination is a package, not a path

The merged text says the copy goes to "the same path inside the patch". That is true for one of the three. Verified file by file:

| | here | patch |
|---|---|---|
| Swing | `client/src/org/compiere/apps/APanel.java` | `src/main/java/base/org/compiere/apps/APanel.java` |
| ZK | `zkwebui/WEB-INF/src/…/GridPanel.java` | `zkwebui/WEB-INF/src/…/GridPanel.java` |
| core | `base/src/org/compiere/model/MOrder.java` | `base/src/main/java/base/org/compiere/model/MOrder.java` |

Shadowing works on the fully-qualified name, so what has to be preserved is the **package**. The source root differs per patch, and the marker now declares each one's `strip` and `source_root` so the destination is computed rather than assumed.

A file placed at this repository's path inside the Swing patch **compiles and shadows nothing** — the failure that looks most like success.

## Also recorded: `surface`

`adempiere_patch_swing` holds `APanel` and `AEnv`; `adempiere_patch_zk` holds `AdempiereWebUI` and `GridPanel`. Same layer, different surfaces.

Their markers record that as `surface`, not as `type`. Typing them `Swing UI` and `Web UI` would import that classification's rule that a UI repository must not contain reusable business logic — and overriding a controller is behaviour, not presentation. It would forbid exactly what those repositories exist to do.